### PR TITLE
Remove setting of region & output format. Solves #72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.3.1] 2019-01-30
+### Fixed:
+- Removed setting region and output format in aws credentials file. (#72)
+
 ## [0.3.0] 2018-12-10
 ### Added:
 - Ability to set requested token duration. (#43).

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -116,8 +116,6 @@ of roles assigned to you.""" % self.role)
 
     def write_sts_token(self, profile, access_key_id, secret_access_key, session_token):
         """ Writes STS auth information to credentials file """
-        region = 'us-east-1'
-        output = 'json'
         if not os.path.exists(self.creds_dir):
             os.makedirs(self.creds_dir)
         config = RawConfigParser()
@@ -128,8 +126,6 @@ of roles assigned to you.""" % self.role)
         if not config.has_section(profile):
             config.add_section(profile)
 
-        config.set(profile, 'output', output)
-        config.set(profile, 'region', region)
         config.set(profile, 'aws_access_key_id', access_key_id)
         config.set(profile, 'aws_secret_access_key', secret_access_key)
         config.set(profile, 'aws_session_token', session_token)

--- a/oktaawscli/version.py
+++ b/oktaawscli/version.py
@@ -1,2 +1,2 @@
 """ version string """
-__version__ = '0.3.0'
+__version__ = '0.3.1'


### PR DESCRIPTION
Region and output format can be set by the user on a per-profile basis in the ~/.aws/config file, and doesn't need to be set to a hard-coded value in the ~/.aws/credentials file. Fixes #72